### PR TITLE
Adding discussion of failing MWDA to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 
-This is legacy code we nevertheless wish to ensure still builds.
+This is legacy code for an extensible version of Java 1.4.
+It builds using [Silver 0.4.5](https://github.com/melt-umn/silver/releases/tag/v0.4.5).
+
+This was written before the [modular well-definedness analysis (MWDA)](https://www-users.cse.umn.edu/~evw/pubs/kaminski12sle/kaminski12sle.pdf) was developed, which is used to ensure grammars will compose without needing user intervention.
+Because this predates MWDA, it does not follow these ideas and does not pass Silver's flow analysis that checks for adherence to MWDA.
+For better examples of large extensible languages written in Silver, see [AbleC](https://github.com/melt-umn/ableC).
 
 ## Notes
 


### PR DESCRIPTION
Since we are removing `autocopy` and not going to fix this due to the large number of flow errors making fixing the removal of `autocopy` nearly impossible, we are abandoning this project.  These changes tell people who stumble across this that it no longer works with new versions of Silver, that it does not pass MWDA and that is bad, and that they should look at AbleC instead.